### PR TITLE
fix broken php version testing in doctor command

### DIFF
--- a/library/Exakat/Tasks/Doctor.php
+++ b/library/Exakat/Tasks/Doctor.php
@@ -386,7 +386,7 @@ INI;
             $stats['configured'] = 'No';
         } else {
             $stats['configured'] = 'Yes';
-            $php = new Phpexec($config);
+            $php = new Phpexec($displayedVersion);
             $version = $php->getVersion();
             if (strpos($version, 'not found') !== false) {
                 $stats['installed'] = 'No';


### PR DESCRIPTION
PHP version testing in doctor command has been broken. Phpexec class constructor requires PHP version, but [this line](https://github.com/exakat/exakat/blob/master/library/Exakat/Tasks/Doctor.php#L389) pass PHP execution path to there.

## before

```
$ php exakat doctor

Error : No PHP binary for version /usr/local/bin/php56 is available. Please, check config/exakat.ini 
on file /opt/exakat/exakat/library/Exakat/Phpexec.php
on line 142
Stopping execution

```

## fixed!

```bash
$ php exakat doctor

... trimmed ...

PHP 5.6 : 
    configured           : Yes
    version              : 5.6.28
    short_open_tags      : Off
    timezone             : 
    tokenizer            : Yes
    memory_limit         : 128M

PHP 7.0 : 
    configured           : No

PHP 7.1 : 
    configured           : Yes
    version              : 7.1.0RC3
    short_open_tags      : Off
    timezone             : 
    tokenizer            : Yes
    memory_limit         : 128M

... trimmed ...

```