### PR TITLE
Remove Content-Length From get request

### DIFF
--- a/library/Exakat/Graph/Gremlin3.php
+++ b/library/Exakat/Graph/Gremlin3.php
@@ -160,8 +160,7 @@ GREMLIN;
         $ch = curl_init();
 
         //set the url, number of POST vars, POST data
-        $headers = array( 'Content-Length: '.strlen($getString),
-                          'User-Agent: exakat',
+        $headers = array('User-Agent: exakat',
                           'X-Stream: true');
         if (!empty($this->neo4j_auth)) {
             $headers[] = 'Authorization: Basic '.$this->neo4j_auth;


### PR DESCRIPTION
Removed Content-Length from curl get request because is not not necessary and resulted in producing timeouts on ubuntu 16.04 / jetty 9.2 / neo4j 2.3.7. This slows down (default timeout = 30 seconds) / disables analyzing. 

Without the content length header there are no errors

**Error from the neo4j console.log**
java.io.IOException: java.util.concurrent.TimeoutException: Idle timeout expired: 30014/30000 ms
	at org.eclipse.jetty.util.SharedBlockingCallback$Blocker.block(SharedBlockingCallback.java:234)
	at org.eclipse.jetty.server.HttpInputOverHTTP.blockForContent(HttpInputOverHTTP.java:66)
	at org.eclipse.jetty.server.HttpInput$1.waitForContent(HttpInput.java:475)
	at org.eclipse.jetty.server.HttpInput.read(HttpInput.java:121)
	at ch.qos.logback.access.servlet.TeeServletInputStream.consumeBufferAndReturnAsByteArray(TeeServletInputStream.java:56)
	at ch.qos.logback.access.servlet.TeeServletInputStream.duplicateInputStream(TeeServletInputStream.java:42)
	at ch.qos.logback.access.servlet.TeeServletInputStream.<init>(TeeServletInputStream.java:30)
	at ch.qos.logback.access.servlet.TeeHttpServletRequest.<init>(TeeHttpServletRequest.java:43)
	at ch.qos.logback.access.servlet.TeeFilter.doFilter(TeeFilter.java:49)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.neo4j.server.guard.GuardingRequestFilter.doFilter(GuardingRequestFilter.java:68)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.neo4j.server.rest.web.CollectUserAgentFilter.doFilter(CollectUserAgentFilter.java:69)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:221)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerList.handle(HandlerList.java:52)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.handler.RequestLogHandler.handle(RequestLogHandler.java:95)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:497)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.util.concurrent.TimeoutException: Idle timeout expired: 30014/30000 ms
	at org.eclipse.jetty.io.IdleTimeout.checkIdleTimeout(IdleTimeout.java:161)
	at org.eclipse.jetty.io.IdleTimeout$1.run(IdleTimeout.java:50)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	... 1 more
