### PR TITLE
Rename Codesniffer in formats to match capitalization

### DIFF
--- a/library/Exakat/Reports/Reports.php
+++ b/library/Exakat/Reports/Reports.php
@@ -37,7 +37,7 @@ abstract class Reports {
                                           'Text', 'Xml', 'Uml',
                                           'PhpConfiguration', 'PhpCompilation',
                                           'Inventories', 'Clustergrammer', 'FileDependencies', 'FileDependenciesHtml',
-                                          'ZendFramework',  'RadwellCode', 'Codesniffer', 'Slim',
+                                          'ZendFramework',  'RadwellCode', 'CodeSniffer', 'Slim',
                                           'FacetedJson', 'Json', 'OnepageJson',
                                           'Codacy',
                                           );


### PR DESCRIPTION
Generating reports command is case-sensitive. CodeSniffer was marked as "Codesniffer" resulting in error when trying to generate a report for CodeSniffer.

https://github.com/exakat/exakat/issues/20
