### PR TITLE
bugfix.  Tinkergraph getDefinitionSQL method.

### DIFF
--- a/library/Exakat/Graph/Tinkergraph.php
+++ b/library/Exakat/Graph/Tinkergraph.php
@@ -244,7 +244,7 @@ class Tinkergraph extends Graph {
 
     public function getDefinitionSQL() {
         return <<<SQL
-SELECT DISTINCT CASE WHEN definitions.id IS NULL THEN definitions2.id - 1 ELSE definitions.id - 1 END AS definition, calls.id - 1 AS call
+SELECT DISTINCT CASE WHEN definitions.id IS NULL THEN definitions2.id ELSE definitions.id END AS definition, calls.id AS call
 FROM calls
 LEFT JOIN definitions 
     ON definitions.type       = calls.type       AND


### PR DESCRIPTION
Tinkergraph project id starts from 1, bug gsneo4j project id starts from 0.
So Tinkergraph getDefinitionSQL method should not same as GSNeo4j.