### PR TITLE
Fix 'Ambassador' spelling.

### DIFF
--- a/docs/Commands.rst
+++ b/docs/Commands.rst
@@ -569,7 +569,7 @@ All reports are detailed in the ref:`Reports <reports>` section.
 +-------------+-----------------------------------------------------------------------------+
 | Report      | Description                                                                 |
 +-------------+-----------------------------------------------------------------------------+
-| Amabassador | HTML format, with all available reports in one compact format.              |
+| Ambassador | HTML format, with all available reports in one compact format.              |
 +-------------+-----------------------------------------------------------------------------+
 | Devoops     | HTML format, deprecated.                                                    |
 +-------------+-----------------------------------------------------------------------------+

--- a/docs/src/Commands.rst
+++ b/docs/src/Commands.rst
@@ -569,7 +569,7 @@ All reports are detailed in the ref:`Reports <reports>` section.
 +-------------+-----------------------------------------------------------------------------+
 | Report      | Description                                                                 |
 +-------------+-----------------------------------------------------------------------------+
-| Amabassador | HTML format, with all available reports in one compact format.              |
+| Ambassador | HTML format, with all available reports in one compact format.              |
 +-------------+-----------------------------------------------------------------------------+
 | Devoops     | HTML format, deprecated.                                                    |
 +-------------+-----------------------------------------------------------------------------+


### PR DESCRIPTION
Changes some instances where 'Ambassador' was spelled 'Amabassador'.