### PR TITLE
Fixed incorrect assignment to array variable

### DIFF
--- a/library/Exakat/Tasks/Install.php
+++ b/library/Exakat/Tasks/Install.php
@@ -32,7 +32,7 @@ class Install extends Tasks {
 
         $res = shell_exec('java -version 2>&1');
         if (strpos($res, 'java version') === false) {
-            $error = 'Please install Java 1.8';
+            $error[] = 'Please install Java 1.8';
         } else {
             print "Java 1.8 : OK\n";
         }


### PR DESCRIPTION
This fixes the assignment of a string value to a variable that is used as an array later on.

Without this fix, following the instructions here: https://exakat.readthedocs.io/en/latest/Installation.html#composer-installation-first-run on a machine that does not have Java installed, would cause the following error:

```
Fatal error: Uncaught Error: [] operator not supported for strings in .../exakat/vendor/exakat/exakat/library/Exakat/Tasks/Install.php on line 48
```

After applaying this fix, the installation task gives the desired output:

```
Zip 3.0 : OK
Please install Java 1.8
Fix the above 1 and try again
```



